### PR TITLE
chore(package): update loglevel-mixin to version 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/Kronos-Integration/kronos-step#readme",
   "dependencies": {
     "kronos-endpoint": "^2.13.4",
-    "loglevel-mixin": "^1.6.0",
+    "loglevel-mixin": "^1.6.1",
     "merge-deep": "^3.0.0",
     "statetransition-mixin": "^3.1.0"
   },


### PR DESCRIPTION
https://greenkeeper.io/